### PR TITLE
Feature: Keep track of 'play count' of tracks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'test-unit'
 gem 'therubyracer'
 gem 'twitter-bootstrap-rails', '2.2.8'
 
+gem 'rack-rewrite', '~> 1.5.0'
+
 group :assets do
   gem 'coffee-rails', '~> 3.2.1'
   gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,7 @@ GEM
       rack (>= 1.2.0)
     rack-protection (1.5.3)
       rack
+    rack-rewrite (1.5.1)
     rack-ssl (1.3.4)
       rack
     rack-test (0.6.3)
@@ -253,6 +254,7 @@ DEPENDENCIES
   pg_search
   pry
   rack-mini-profiler
+  rack-rewrite (~> 1.5.0)
   rails (= 3.2.22.5)
   resque
   ruby-mp3info
@@ -269,4 +271,4 @@ RUBY VERSION
    ruby 2.2.3p173
 
 BUNDLED WITH
-   1.13.6
+   1.16.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,5 +79,11 @@ module Phishin
     #   :enable_starttls_auto   => true
     # }
 
+    before_assets_load = Rails.env.production? ? Rack::Lock : ActionDispatch::Static
+    
+    config.middleware.insert_before(before_assets_load, Rack::Rewrite) do
+      r301 %r{/audio/\w{3}/\w{3}/\w{3}/(.*?).mp3}, '/tracker/audio/$1'
+    end
+
   end
 end

--- a/config/routes/web.rb
+++ b/config/routes/web.rb
@@ -61,7 +61,7 @@ Phishin::Application.routes.draw do
 
   # Downloads
   get '/track-info/:track_id' => 'downloads#track_info', as: 'track_info'
-  get '/play-track/:track_id' => 'downloads#play_track', as: 'play_track'
+  get '/tracker/audio/:track_id' => 'downloads#tracker'
   get '/download-track/:track_id' => 'downloads#download_track', as: 'download_track'
   get '/download-show/:date' => 'downloads#request_download_show', as: 'download_show'
   get '/download/:md5' => 'downloads#download_album', as: 'download_album'

--- a/db/migrate/20171130170435_add_play_count_to_track.rb
+++ b/db/migrate/20171130170435_add_play_count_to_track.rb
@@ -1,0 +1,5 @@
+class AddPlayCountToTrack < ActiveRecord::Migration
+  def change
+    add_column :tracks, :play_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170811053628) do
+ActiveRecord::Schema.define(:version => 20171130170435) do
 
   create_table "album_requests", :force => true do |t|
     t.integer  "album_id"
@@ -206,6 +206,7 @@ ActiveRecord::Schema.define(:version => 20170811053628) do
     t.integer  "likes_count",             :default => 0
     t.string   "slug"
     t.integer  "tags_count",              :default => 0
+    t.integer  "play_count",              :default => 0
   end
 
   add_index "tracks", ["likes_count"], :name => "index_tracks_on_likes_count"


### PR DESCRIPTION
I created a mod_rewrite that redirects from the audio asset to an endpoint that increments the play count / and returns the mp3 file, as a way to 'track' any client requesting the Phish mp3s.

It could have been written on the client-side (Same endpoint 'tracker', no redirect, but both Phish.in JS /  Chris's client would do an extra request). 

The reason it was done as a 'redirect' is because it would be  beneficial to include any traffic as a 'hit' for Chris's neutral network, and redirecting involves no extra code for every client out there. What do you think?