### PR TITLE
Add phishnet:setlist_tags rake task

### DIFF
--- a/app/services/show_importer/show_info.rb
+++ b/app/services/show_importer/show_info.rb
@@ -3,12 +3,10 @@ require 'open-uri'
 require 'nokogiri'
 
 class ShowImporter::ShowInfo
-  PNET_API_KEY = '448345A7B7688DDE43D0'
-
   attr_reader :songs, :pnet
 
   def initialize(date)
-    @pnet = ShowImporter::PNet.new(PNET_API_KEY)
+    @pnet = ShowImporter::PNet.new(ENV['PNET_API_KEY'])
     @data = parse_data(date)
     songs = parse_songs
     raise 'Invalid date' if songs.empty?

--- a/app/views/static_pages/tagin_project.html.slim
+++ b/app/views/static_pages/tagin_project.html.slim
@@ -104,11 +104,12 @@
 
     h2 Crowd Interaction
     ul
-      li "Woo"s
+      li "Woo"s (appearing outside Twist)
       li Anytime a crowd member is brought onstage even if they don't speak
-      li Random interactions: "Fuck You" from 1991-10-31 Wait, for example
+      li Unique interactions: "Fuck You" from 1991-10-31 Wait, for example
+      li Does NOT include the common ones like Stash claps, Gin "take a bath", or applause during Divided Sky pause
       li Notes section should contain brief summary of interaction
-      li If there are extensive spoken words, they should be transcribed and pasted into Transcript field
+      li If there are spoken words, they should be transcribed and pasted into Transcript field
 
     h2 Famous (Jam)
     ul

--- a/lib/tasks/phishnet.rake
+++ b/lib/tasks/phishnet.rake
@@ -3,6 +3,69 @@ namespace :phishnet do
   desc 'Sync jamcharts data'
   task jamcharts: :environment do
     puts 'Fetching Jamcharts data from Phish.net API...'
-    JamchartsImporter.new(ENV['PHISHNET_API_KEY']).call
+    JamchartsImporter.new(ENV['PNET_API_KEY']).call
+  end
+
+  task setlist_tags: :environment do
+    relation = Show.unscoped.order(date: :asc)
+
+    # rig_tag = Tag.find_by(name: 'Alternate Rig')
+    # TrackTag.where(tag: rig_tag).destroy_all
+
+    # guest_tag = Tag.find_by(name: 'Guest')
+    # TrackTag.where(tag: guest_tag).destroy_all
+
+    debut_tag = Tag.find_by(name: 'Debut')
+    TrackTag.where(tag: debut_tag).destroy_all
+
+    phish_debut_tag = Tag.find_by(name: 'Phish Debut')
+    TrackTag.where(tag: phish_debut_tag).destroy_all
+
+    pbar = ProgressBar.create(total: relation.count, format: '%a %B %c/%C %p%% %E')
+
+    relation.each do |show|
+      date = show.date
+
+      resp =
+        HTTParty.get(
+          "https://api.phish.net/v3/setlists/get?apikey=#{ENV['PNET_API_KEY']}&showdate=#{date}"
+        ).body
+      data = JSON[resp].dig('response', 'data')&.first
+
+      next unless data.present?
+
+      notes = Nokogiri.HTML(data['setlistdata']).css('.setlist-song + sup')
+
+      notes.each do |note|
+        text = note['title']
+        title = note.previous_sibling.content
+
+        tag = nil
+        if text.downcase.include?('phish debut')
+          tag = phish_debut_tag
+        elsif text.downcase.include?('debut')
+          tag = debut_tag
+        end
+        next unless tag
+
+        track =
+          Track.where(show: show)
+               .where(
+                 'title = ? or title LIKE ? or title LIKE ? or title LIKE ? or title LIKE ?',
+                 title,
+                 "%> #{title}",
+                 "#{title} >%",
+                 "%> #{title} >%",
+                 "#{title}, %"
+               ).first
+        next puts "Missing: #{date} #{title}" unless track
+
+        TrackTag.create(track: track, tag: tag)
+      end
+
+      pbar.increment
+    end
+
+    pbar.finish
   end
 end


### PR DESCRIPTION
Fixes #96 

Adds `phishnet:setlist_tags` to import Debut and Phish Debut tags.  Guest tag processing coming soon.  Leaving Bustout tag out for now - maybe revisit later.