### PR TITLE
Allow multiple tags

### DIFF
--- a/app/models/track_tag.rb
+++ b/app/models/track_tag.rb
@@ -2,6 +2,4 @@
 class TrackTag < ApplicationRecord
   belongs_to :track, counter_cache: :tags_count
   belongs_to :tag, counter_cache: :tracks_count
-
-  validates :track, uniqueness: { scope: :tag_id }
 end

--- a/app/views/my/my_shows.html.slim
+++ b/app/views/my/my_shows.html.slim
@@ -21,7 +21,6 @@
               a href="/#{show.venue.slug}" = truncate(show.venue_name, length: 45)
             h5.narrower.small-font
               a href="/map?map_term=#{CGI.escape(show.venue.location)}" = truncate(show.venue.location, length: 16)
-            = display_tag_instances(show.show_tags, 'tag_container_small')
             = likable(show, @shows_likes[idx], 'small')
             h3 = duration_readable(show.duration, 'letters')
             = render partial: 'shared/context_menu_for_show', locals: { show: show, viewing_this_show: false }

--- a/app/views/my/my_shows.html.slim
+++ b/app/views/my/my_shows.html.slim
@@ -21,7 +21,7 @@
               a href="/#{show.venue.slug}" = truncate(show.venue_name, length: 45)
             h5.narrower.small-font
               a href="/map?map_term=#{CGI.escape(show.venue.location)}" = truncate(show.venue.location, length: 16)
-            = display_tag_instances(show.show_tags, true, 'tag_container_small')
+            = display_tag_instances(show.show_tags, 'tag_container_small')
             = likable(show, @shows_likes[idx], 'small')
             h3 = duration_readable(show.duration, 'letters')
             = render partial: 'shared/context_menu_for_show', locals: { show: show, viewing_this_show: false }

--- a/app/views/playlists/active_playlist.html.slim
+++ b/app/views/playlists/active_playlist.html.slim
@@ -76,10 +76,9 @@
             .drag_arrows_vertical
               i.icon-resize-vertical
             h2.position_num = idx + 1
-            h2.wide = track.title
+            h2.wider = track.title
             h5.narrower
               a href="/#{track.show.date}" = track.show.date_with_dots
-            = display_tag_instances(track.track_tags, 'tag_container_small', 'track')
             = likable(track, @tracks_likes[idx], 'small')
             h3 = duration_readable(track.duration)
             = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: true, show: nil }

--- a/app/views/playlists/active_playlist.html.slim
+++ b/app/views/playlists/active_playlist.html.slim
@@ -79,7 +79,7 @@
             h2.wide = track.title
             h5.narrower
               a href="/#{track.show.date}" = track.show.date_with_dots
-            = display_tag_instances(track.track_tags, true, 'tag_container_small', 'track')
+            = display_tag_instances(track.track_tags, 'tag_container_small', 'track')
             = likable(track, @tracks_likes[idx], 'small')
             h3 = duration_readable(track.duration)
             = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: true, show: nil }

--- a/app/views/shows/index.html.slim
+++ b/app/views/shows/index.html.slim
@@ -24,7 +24,7 @@
                 a href="/#{show.venue.slug}" = truncate(show.venue_name, length: 45)
               h5.narrower.small-font
                 a href="/map?map_term=#{CGI.escape(show.venue.location)}" = truncate(show.venue.location, length: 16)
-              = display_tag_instances(show.show_tags, true, 'tag_container_small')
+              = display_tag_instances(show.show_tags, 'tag_container_small')
               = likable(show, props[:likes][idx], 'small')
               h3 = duration_readable(show.duration, 'letters')
               = render partial: 'shared/context_menu_for_show', locals: { show: show, viewing_this_show: false }

--- a/app/views/shows/show.html.slim
+++ b/app/views/shows/show.html.slim
@@ -18,7 +18,7 @@
     = likable(@show, @show_like, 'large')
     = clear_both
     = render partial: 'shared/context_menu_for_show', locals: { show: @show, viewing_this_show: true, next_show: @next_show, previous_show: @previous_show }
-    = display_tag_instances(@show.show_tags, false, 'show_tag_container_title')
+    = display_tag_instances(@show.show_tags, 'show_tag_container_title')
     .hr
 
     = clear_both
@@ -42,7 +42,7 @@
             li.playable_track data-id=track.id data-track-anchor=track.slug data-section-anchor=slug_for_set(set)
               h2.position_num = idx + 1
               h2.wide.track_title = link_to(track.title, '#')
-              h2.wide-180 = display_tag_instances(track.track_tags, false, 'track_tag_container', 'track')
+              h2.wide-180 = display_tag_instances(track.track_tags, 'track_tag_container', 'track')
               = likable(track, props[:likes][idx], 'small')
               h3 = duration_readable(track.duration)
               = render partial: 'shared/context_menu_for_track', locals: { track: track, show: @show, playlist: false }

--- a/app/views/songs/show.html.slim
+++ b/app/views/songs/show.html.slim
@@ -31,13 +31,12 @@
             h2
               a href="/#{track.show.date}/#{track.slug}" = show_link_title(track.show, false)
             h2.wide-180
-              a href="/#{track.show.venue.slug}" = truncate(track.show.venue_name, length: 30)
+              a href="/#{track.show.venue.slug}" = truncate(track.show.venue_name, length: 35)
             h5.narrow
               a href="/map?map_term=#{CGI.escape(track.show.venue.location)}" = truncate(track.show.venue.location, length: 20)
             = likable(track, @tracks_likes[idx], 'small')
             h3 = duration_readable(track.duration)
             = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: false, show: nil }
-            = display_tag_instances(track.track_tags, 'tag_container_small')
             = clear_both
 
     - if @tracks.total_pages > 1

--- a/app/views/songs/show.html.slim
+++ b/app/views/songs/show.html.slim
@@ -37,7 +37,7 @@
             = likable(track, @tracks_likes[idx], 'small')
             h3 = duration_readable(track.duration)
             = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: false, show: nil }
-            = display_tag_instances(track.track_tags, true, 'tag_container_small')
+            = display_tag_instances(track.track_tags, 'tag_container_small')
             = clear_both
 
     - if @tracks.total_pages > 1

--- a/app/views/tags/show.html.slim
+++ b/app/views/tags/show.html.slim
@@ -23,12 +23,13 @@
             li
               h2
                 a href="/#{show.date}" = show.date_with_dots
-              h2.wide-180
+              h2.wider
                 a href="/#{show.venue.slug}" = truncate(show.venue_name, length: 35)
+              h2
+                a href="/map?map_term=#{CGI.escape(show.venue.location)}" = truncate(show.venue.location, length: 20)
               = likable(show, @shows_likes[idx], 'small')
               h3 = duration_readable(show.duration, 'letters')
               = render partial: 'shared/context_menu_for_show', locals: { show: show, viewing_this_show: false }
-              = display_tag_instances(show.show_tags)
               = clear_both
         - else
           .alert_container Selected tag is not associated with any shows
@@ -37,11 +38,10 @@
         - if @tracks.any?
           - @tracks.each_with_index do |track, idx|
             li.playable_track data-id=track.id
-              h2.wide
-                a href="/#{track.show.date}/#{track.slug}" = truncate(track.title, length: 44)
-              h5.narrow
+              h2.wider
+                a href="/#{track.show.date}/#{track.slug}" = truncate(track.title, length: 45)
+              h5.narrower
                 a href="/#{track.show.date}" = track.show.date_with_dots
-              = display_tag_instances(track.track_tags, 'tag_container_small')
               = likable(track, @tracks_likes[idx], 'small')
               h3 = duration_readable(track.duration)
               = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: false, show: nil }

--- a/app/views/tags/show.html.slim
+++ b/app/views/tags/show.html.slim
@@ -41,7 +41,7 @@
                 a href="/#{track.show.date}/#{track.slug}" = truncate(track.title, length: 44)
               h5.narrow
                 a href="/#{track.show.date}" = track.show.date_with_dots
-              = display_tag_instances(track.track_tags, true, 'tag_container_small')
+              = display_tag_instances(track.track_tags, 'tag_container_small')
               = likable(track, @tracks_likes[idx], 'small')
               h3 = duration_readable(track.duration)
               = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: false, show: nil }

--- a/app/views/top_shows/index.html.slim
+++ b/app/views/top_shows/index.html.slim
@@ -23,7 +23,7 @@
           = likable(show, @shows_likes[idx], 'small')
           h3.narrow = duration_readable(show.duration, 'letters')
           = render partial: 'shared/context_menu_for_show', locals: { show: show, viewing_this_show: false }
-          = display_tag_instances(show.show_tags, true)
+          = display_tag_instances(show.show_tags)
           = clear_both
 
   = clear_both

--- a/app/views/top_shows/index.html.slim
+++ b/app/views/top_shows/index.html.slim
@@ -18,12 +18,11 @@
           h2.position_num = idx + 1
           h2
             a href="/#{show.date}" = show.date_with_dots
-          h4.narrow
-            a href="/#{show.venue.slug}" = truncate(show.venue_name, length: 30)
+          h2.widest
+            a href="/#{show.venue.slug}" = show.venue_name
           = likable(show, @shows_likes[idx], 'small')
           h3.narrow = duration_readable(show.duration, 'letters')
           = render partial: 'shared/context_menu_for_show', locals: { show: show, viewing_this_show: false }
-          = display_tag_instances(show.show_tags)
           = clear_both
 
   = clear_both

--- a/app/views/top_tracks/index.html.slim
+++ b/app/views/top_tracks/index.html.slim
@@ -20,7 +20,7 @@
             a href="/#{track.show.date}/#{track.slug}" = truncate(track.title, length: 44)
           h5.narrow
             a href="/#{track.show.date}" = track.show.date_with_dots
-          = display_tag_instances(track.track_tags, true, 'tag_container_small', 'track')
+          = display_tag_instances(track.track_tags, 'tag_container_small', 'track')
           = likable(track, @tracks_likes[idx], 'small')
           h3 = duration_readable(track.duration)
           = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: false, show: nil }

--- a/app/views/top_tracks/index.html.slim
+++ b/app/views/top_tracks/index.html.slim
@@ -16,11 +16,10 @@
       - @tracks.each_with_index do |track, idx|
         li.playable_track data-id=track.id
           h2.position_num = idx + 1
-          h5.width-200
+          h2.wider
             a href="/#{track.show.date}/#{track.slug}" = truncate(track.title, length: 44)
           h5.narrow
             a href="/#{track.show.date}" = track.show.date_with_dots
-          = display_tag_instances(track.track_tags, 'tag_container_small', 'track')
           = likable(track, @tracks_likes[idx], 'small')
           h3 = duration_readable(track.duration)
           = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: false, show: nil }

--- a/app/views/venues/show.html.slim
+++ b/app/views/venues/show.html.slim
@@ -35,7 +35,7 @@
             = likable(show, @shows_likes[idx], 'small')
             h3 = duration_readable(show.duration, 'letters')
             = render partial: 'shared/context_menu_for_show', locals: { show: show, viewing_this_show: false }
-            = display_tag_instances(show.show_tags, true, 'tag_container_small')
+            = display_tag_instances(show.show_tags, 'tag_container_small')
             = clear_both
 
   = clear_both

--- a/app/views/venues/show.html.slim
+++ b/app/views/venues/show.html.slim
@@ -35,7 +35,6 @@
             = likable(show, @shows_likes[idx], 'small')
             h3 = duration_readable(show.duration, 'letters')
             = render partial: 'shared/context_menu_for_show', locals: { show: show, viewing_this_show: false }
-            = display_tag_instances(show.show_tags, 'tag_container_small')
             = clear_both
 
   = clear_both

--- a/db/migrate/20190128032845_remove_unique_idx_on_track_tags.rb
+++ b/db/migrate/20190128032845_remove_unique_idx_on_track_tags.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class RemoveUniqueIdxOnTrackTags < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :track_tags, name: :index_track_tags_on_tag_id_and_track_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_27_220532) do
+ActiveRecord::Schema.define(version: 2019_01_28_032845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -168,7 +168,6 @@ ActiveRecord::Schema.define(version: 2019_01_27_220532) do
     t.integer "ends_at_second"
     t.text "transcript"
     t.index ["notes"], name: "index_track_tags_on_notes"
-    t.index ["tag_id", "track_id"], name: "index_track_tags_on_tag_id_and_track_id", unique: true
     t.index ["tag_id"], name: "index_track_tags_on_tag_id"
     t.index ["track_id"], name: "index_track_tags_on_track_id"
   end

--- a/spec/models/track_tag_spec.rb
+++ b/spec/models/track_tag_spec.rb
@@ -8,6 +8,4 @@ RSpec.describe TrackTag do
 
   it { is_expected.to belong_to(:track).counter_cache(:tags_count) }
   it { is_expected.to belong_to(:tag).counter_cache(:tracks_count) }
-
-  it { is_expected.to validate_uniqueness_of(:track).scoped_to(:tag_id) }
 end


### PR DESCRIPTION
* Allows multiple tags of same type on a track, so we can have multiple Teases.
* Stacks the teases on display like `Tease (2)`.  
* Fixes #89 