### PR TITLE
Add share with timestamp to track context menus

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -412,6 +412,10 @@ $ ->
   .on 'click', '.share', ->
     App.Util.copyToClipboard($('body').data('base-url')+$(this).data('url'))
 
+  .on 'click', '.share_with_timestamp', ->
+    time = App.Util.readableDuration App.Player.currentPosition()
+    App.Util.copyToClipboard($('body').data('base-url')+$(this).data('url')+'?'+time)
+
   # Play random song track
   .on 'click', '#random_song_track_btn', (e) ->
     App.Player.playRandomSongTrack $(this).data('song-id')

--- a/app/assets/javascripts/classes/player.js.coffee
+++ b/app/assets/javascripts/classes/player.js.coffee
@@ -46,6 +46,8 @@ class @Player
             this.togglePause()
             alert 'Touch the Play button to begin playback. Your browser does not support auto-play.'
 
+  currentPosition: ->
+    @sm_sound.position
 
   togglePlaylistMode: ->
     if @playlist_mode

--- a/app/views/shared/_context_menu_for_playlist.html.slim
+++ b/app/views/shared/_context_menu_for_playlist.html.slim
@@ -11,3 +11,7 @@
         a.share href='null' data-url="/play/#{playlist.slug}"
           i.icon-share-alt
           |  Share
+      li
+        a.share_with_timestamp.share_track href='null' data-url="/#{show ? show.date : track.show.date}/#{track.slug}"
+          i.icon-share-alt
+          |  Share with timestamp

--- a/app/views/shared/_context_menu_for_track.html.slim
+++ b/app/views/shared/_context_menu_for_track.html.slim
@@ -25,6 +25,10 @@
           i.icon-share-alt
           |  Share
       li
+        a.share_with_timestamp.share_track href='null' data-url="/#{show ? show.date : track.show.date}/#{track.slug}"
+          i.icon-share-alt
+          |  Share with timestamp
+      li
         a.download href='null' data-url=download_track_path(track.id)
           i.icon-download
           |  Download MP3


### PR DESCRIPTION
Fixes #110 

<img width="209" alt="screen shot 2019-01-29 at 7 21 42 pm" src="https://user-images.githubusercontent.com/104095/51956079-21a90800-23fb-11e9-848c-ee0e4898f507.png">
