### PR TITLE
CSS fix for show dropdown bug

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1145,6 +1145,7 @@ html {
     padding: 20px 20px 10px 20px;
     border-radius: 10px;
     font-family: 'Open Sans Condensed', sans-serif;
+    z-index: 1;
 
     h1 {
       line-height: 24px;


### PR DESCRIPTION
While the stacking strategy in general could use a little cleaning up, here's a minimal patch to fix the stacking of the show dropdown box – simply setting `z-index: 1` for `title_box` does the trick:

![image](https://user-images.githubusercontent.com/943217/52017275-be22e700-249b-11e9-944f-7bc2a2595d67.png)