### PR TITLE
Sanitize txt on Tagin imports

### DIFF
--- a/app/services/track_tag_sync_service.rb
+++ b/app/services/track_tag_sync_service.rb
@@ -2,6 +2,8 @@
 require 'csv'
 
 class TrackTagSyncService
+  include ActionView::Helpers::SanitizeHelper
+
   attr_reader :tag, :data
   attr_reader :track, :created_ids, :updated_ids, :dupes
 
@@ -48,16 +50,22 @@ class TrackTagSyncService
     end
   end
 
+  def sanitize_str(str)
+    sanitize(str.gsub(/[”“]/, '"').gsub(/[‘’]/, "'"))
+  end
+
   def create_track_tag(row)
     print '.'
+    notes = sanitize_str(row['Notes'])
+    transcript = sanitize_str(row['Transcript'])
     @created_ids <<
       TrackTag.create!(
         tag: tag,
         track: track,
         starts_at_second: seconds_or_nil(row['Starts At']),
         ends_at_second: seconds_or_nil(row['Ends At']),
-        notes: row['Notes'],
-        transcript: row['Transcript']
+        notes: notes,
+        transcript: transcript
       ).id
   end
 
@@ -66,8 +74,8 @@ class TrackTagSyncService
     tt.update(
       starts_at_second: seconds_or_nil(row['Starts At']),
       ends_at_second: seconds_or_nil(row['Ends At']),
-      notes: row['Notes'],
-      transcript: row['Transcript']
+      notes: notes,
+      transcript: transcript
     )
     @updated_ids << tt.id
   end

--- a/lib/tasks/phishnet.rake
+++ b/lib/tasks/phishnet.rake
@@ -13,7 +13,6 @@ namespace :phishnet do
     relation = Show.unscoped.order(date: :asc)
 
     debut_tag = Tag.find_by(name: 'Debut')
-    phish_debut_tag = Tag.find_by(name: 'Phish Debut')
     signal_tag = Tag.find_by(name: 'Signal')
 
     csv_guest = []
@@ -59,8 +58,6 @@ namespace :phishnet do
           if downtxt.include?('signal')
             tag = signal_tag
             notes = txt.strip.chomp('.')
-          elsif downtxt.include?('phish debut')
-            tag = phish_debut_tag
           elsif downtxt.include?('debut')
             tag = debut_tag
           elsif downtxt.include?('guest') || downtxt =~ /\son\s/

--- a/lib/tasks/phishnet.rake
+++ b/lib/tasks/phishnet.rake
@@ -8,6 +8,8 @@ namespace :phishnet do
 
   desc 'Syncs various tags and outputs CSV for Guest/Alt Rig'
   task setlist_tags: :environment do
+    include ActionView::Helpers::SanitizeHelper
+
     relation = Show.unscoped.order(date: :asc)
 
     debut_tag = Tag.find_by(name: 'Debut')
@@ -33,7 +35,7 @@ namespace :phishnet do
       notes = Nokogiri.HTML(data['setlistdata']).css('.setlist-song + sup')
 
       notes.each do |note|
-        text = note['title']
+        text = sanitize(note['title'].gsub(/[”“]/, '"').gsub(/[‘’]/, "'"))
         title = note.previous_sibling.content
 
         track =

--- a/lib/tasks/tagin.rake
+++ b/lib/tasks/tagin.rake
@@ -46,9 +46,9 @@ namespace :tagin do
     end
   end
 
-  desc 'Apply Costume Set tag to shows and tracks'
+  desc 'Apply Costume tag to shows and tracks'
   task costume: :environment do
-    tag = Tag.find_by(name: 'Costume Set')
+    tag = Tag.find_by(name: 'Costume')
     show_data = {
       '1994-10-31' => 'The White Album by The Beatles',
       '1996-10-31' => 'Remain In Light by Talking Heads',


### PR DESCRIPTION
Replace UTF quotes and escape HTML/css.

Fixes #118 

Other: combine Debut/Phish Debut tags, shorten Costume Set.