### PR TITLE
Tooltip improvements

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -60,7 +60,10 @@ $ ->
 
           # Tooltips
           $('a[title]').tooltip()
-          $('.tag_label[title]').tooltip()
+          $('.tag_label[title]').tooltip
+            delay:
+              show: 50
+              hide: 5000
 
           # Auto-scroll and highlight track anchor if present
           if state.data.href.substr(0,6) != '/play/' and path = state.data.href.split("/")[2]

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1111,6 +1111,7 @@ html {
     height: 15px !important;
     float: right;
     width: 200px;
+    overflow: visible;
 
     .tag_label {
       float: right;
@@ -1276,6 +1277,14 @@ html {
       background-color: #eee;
       border-radius: 5px;
       border: 1px solid black;
+    }
+    .tooltip-inner {
+      white-space: pre-wrap;
+      max-width: 1000px;
+      max-height: 600px;
+      font-size: 12px;
+      text-align: left;
+      overflow-y: scroll;
     }
     #google_map {
       width: 100%;

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -62,9 +62,9 @@ module TagHelper
         if end_timestamp(t)
           title += "Ends at #{end_timestamp(t)}<br>"
         end
-        title += wrapped_str(t.notes) if t.notes.present?
+        title += t.notes if t.notes.present?
         if t.try(:transcript)&.present?
-          title += "<br><br>-TRANSCRIPT-<br> #{wrapped_str(t.transcript)}"
+          title += "<br><br>-TRANSCRIPT-<br> #{collapse_newlines(t.transcript)}"
         end
       end
 
@@ -86,10 +86,14 @@ module TagHelper
     tag_timestamp(t.ends_at_second)
   end
 
-  def wrapped_str(str)
-    word_wrap(str, line_width: 50).gsub("\n", '<br>')
+  def wrapped_str(str,line_width=50)
+    word_wrap(str, line_width: line_width).gsub("\n", '<br>')
   end
 
+  def collapse_newlines(str)
+    str.squeeze("\n")
+  end
+  
   def tag_timestamp(timestamp)
     duration_readable(timestamp * 1000, 'colons')
   end


### PR DESCRIPTION
For longer tooltips under tags (e.g. Narrations), here are some incrememntal improvements to the current truncated behavior:

1. hovering over a tooltip now displays it for 5 seconds
2. CSS-based wrapping and scrolling
3. newline squeezing

Optimal behavior, which I haven't yet cracked using current dependencies, would be for tooltips to remain displayed while hovering over both the target and and the tooltip itself. There are many (proposed) solutions online, some jQuery-based (e.g. pTooltip), some vanilla JS-based (e.g. tippy.js), and others. @jcraigk would like to limit dependencies, understandably so, so I'm working on finding a way to implement a solution within the current constraints (unsuccessful to date).