### PR TITLE
Add tag detail modal, cleanup tag display

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -422,9 +422,15 @@ $ ->
 
   # Taper Notes link opens a modal
   .on 'click', '.show_taper_notes', ->
-    $('#taper_notes_content').html($(this).data('taper-notes'))
+    $('#taper_notes_content').html $(this).data('taper-notes')
     $('#taper_notes_date').html $(this).data('show-date')
     $('#taper_notes_modal').modal('show')
+
+  # Tag instance click opens a modal
+  .on 'click', '.tag_label', ->
+    $('#tag_detail_title').html $(this).data('detail-title')
+    $('#tag_detail').html $(this).data('detail')
+    $('#tag_modal').modal('show')
 
   # Keyboard shortcuts
   $(window).keydown (e) ->

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -90,7 +90,15 @@ $highlight4: #fff494;
     text-decoration: underline;
   }
 }
-
+#tag_detail {
+  font-size: 20px;
+  line-height: 26px;
+}
+.detail_tag_label {
+  font-size: 20px !important;
+  padding: 10px !important;
+  margin-bottom: 10px;
+}
 
 html {
   margin: 0;
@@ -1121,6 +1129,7 @@ html {
     height: 15px !important;
     float: right;
     width: 200px;
+    overflow: visible;
 
     .tag_label {
       float: right;
@@ -1286,6 +1295,13 @@ html {
       background-color: #eee;
       border-radius: 5px;
       border: 1px solid black;
+    }
+    .tooltip-inner {
+      white-space: pre-wrap;
+      max-width: 1000px;
+      max-height: 600px;
+      font-size: 12px;
+      overflow-y: scroll;
     }
     #google_map {
       width: 100%;

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,6 +18,7 @@ html
     = render partial: 'layouts/feedback'
     = render partial: 'layouts/ajax_overlay'
     = render partial: 'shared/taper_notes_modal'
+    = render partial: 'shared/tag_modal'
     = render partial: 'shared/save_playlist_modal'
     = render partial: 'shared/clipboard'
     = render partial: 'layouts/page_header'

--- a/app/views/shared/_tag_modal.html.slim
+++ b/app/views/shared/_tag_modal.html.slim
@@ -1,0 +1,8 @@
+#tag_modal.modal.hide.fade
+  .modal-header
+    button.close type='button' data-dismiss='modal' aria-hidden='true' ×
+    h3#tag_detail_title [title]
+  .modal-body
+    p#tag_detail
+  .modal-footer
+    a href='/tags' class='btn' data-dismiss='modal' View All Tags

--- a/app/views/tags/show.html.slim
+++ b/app/views/tags/show.html.slim
@@ -4,7 +4,8 @@
   #title_box
     = tag_label(@tag, :large_tag_label)
     = clear_both
-    p = @tag.description
+    h3 = @tag.description
+    br
 
     .btn-group
       button.btn class=(@context == 'show' ? 'active' : '')


### PR DESCRIPTION
Fixes #115 by introducing Tag Detail Modals.  Rollovers will show all data except Transcripts.  Modals show everything in an easier to read (and scrollable) format.

Thanks to @ucpete for CSS.

<img width="1021" alt="screen shot 2019-02-09 at 3 14 24 pm" src="https://user-images.githubusercontent.com/104095/52527464-aa3a6a80-2c7d-11e9-87c3-6d5730227ba4.png">
<img width="617" alt="screen shot 2019-02-09 at 3 14 36 pm" src="https://user-images.githubusercontent.com/104095/52527465-aa3a6a80-2c7d-11e9-9396-b22276679bad.png">
