### PR TITLE
Removed scrollbar on tag tooltips

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1301,7 +1301,6 @@ html {
       max-width: 1000px;
       max-height: 600px;
       font-size: 12px;
-      overflow-y: scroll;
     }
     #google_map {
       width: 100%;


### PR DESCRIPTION
Vestigial element from my experimentation, obviated by modal implementation – i.e. this just looks better.