### PR TITLE
Replace context menu with tag instances on Song show page

### DIFF
--- a/app/views/songs/show.html.slim
+++ b/app/views/songs/show.html.slim
@@ -36,7 +36,7 @@
               a href="/map?map_term=#{CGI.escape(track.show.venue.location)}" = truncate(track.show.venue.location, length: 20)
             = likable(track, @tracks_likes[idx], 'small')
             h3 = duration_readable(track.duration)
-            = render partial: 'shared/context_menu_for_track', locals: { track: track, playlist: false, show: nil }
+            = display_tag_instances(track.track_tags)
             = clear_both
 
     - if @tracks.total_pages > 1


### PR DESCRIPTION
Fixes #135 

The context menu didn't seem especially useful on this page so this removes them to make room for the Tag instances.

<img width="1004" alt="Screen Shot 2019-06-17 at 11 05 16 AM" src="https://user-images.githubusercontent.com/104095/59626166-0dd31980-90f0-11e9-801a-bb6de9c2ab48.png">
