### PR TITLE
Add Phish.net Song History button to Song show page

### DIFF
--- a/app/views/reports/missing_content.html.slim
+++ b/app/views/reports/missing_content.html.slim
@@ -8,7 +8,7 @@
     h2 #{@kdates.size - @incomplete_dates.size} missing shows
     h2 #{@incomplete_dates.size} incomplete shows
     .hr
-    p This list represents all known shows that do not have complete recordings available on this site.
+    p This list represents all known Phish performances that do not have complete audience recordings available in circulation. Over time, new audio sources may surface, at which time they are added to the library. Some of these performances have copyright restrictions due to the venue, such as talk show appearances, and thus will likely never appear on this site.
 
   #content_box
     - @kdates.group_by { |kd| kd.date.year }.each do |year, known_dates|

--- a/app/views/songs/show.html.slim
+++ b/app/views/songs/show.html.slim
@@ -23,6 +23,9 @@
       i.icon.icon-play
       |  Play Random Version
     br
+    a.btn href="http://phish.net/song/#{@song.slug}" target='_blank'
+      i.icon.icon-book>
+      | Phish.net Song History
 
   #content_box
     ul.item_list.clickable

--- a/app/views/static_pages/faq.html.slim
+++ b/app/views/static_pages/faq.html.slim
@@ -16,7 +16,7 @@
 
     p.large
       strong How is it funded?
-    p This site is funded privately by the author. No donations may be accepted according to Phish's taping policy.
+    p This site is funded privately by the author.
     br
 
     p.large


### PR DESCRIPTION
Fixes #95 

<img width="1007" alt="Screen Shot 2019-06-17 at 2 54 20 PM" src="https://user-images.githubusercontent.com/104095/59639545-716d3f00-9110-11e9-8b9b-a0c65a5f3c5a.png">
