### PR TITLE
Improve time formatting

### DIFF
--- a/app/services/duration_formatter.rb
+++ b/app/services/duration_formatter.rb
@@ -23,13 +23,9 @@ class DurationFormatter
   end
 
   def format_with_letters
-    if days.positive?
-      lettered_days_hours_mins_seconds
-    elsif hours.positive?
-      lettered_hours_mins
-    else
-      lettered_mins_seconds
-    end
+    return lettered_days_hours_mins_seconds if days.positive?
+    return lettered_hours_mins if hours.positive?
+    lettered_mins_seconds
   end
 
   def format_with_colons
@@ -52,28 +48,29 @@ class DurationFormatter
     )
   end
 
+  def lettered_hours
+    format('%<hours>dh', hours: hours)
+  end
+
   def lettered_hours_mins
-    format(
-      '%<hours>dh %<minutes>dm',
-      hours: hours,
-      minutes: minutes
-    )
+    return lettered_hours if minutes.zero?
+    format('%<hours>dh %<minutes>dm', hours: hours, minutes: minutes)
+  end
+
+  def lettered_mins
+    format('%<minutes>dm', minutes: minutes)
   end
 
   def lettered_mins_seconds
-    format(
-      '%<minutes>dm %<seconds>ds',
-      minutes: minutes,
-      seconds: seconds
-    )
+    if seconds.zero?
+      return '0s' if minutes.zero?
+      return lettered_mins
+    end
+    format('%<minutes>dm %<seconds>ds', minutes: minutes, seconds: seconds)
   end
 
   def colon_mins_seconds
-    format(
-      '%<minutes>d:%<seconds>02d',
-      minutes: minutes,
-      seconds: seconds
-    )
+    format('%<minutes>d:%<seconds>02d', minutes: minutes, seconds: seconds)
   end
 
   def colon_days_hours_mins_seconds

--- a/spec/services/duration_formatter_spec.rb
+++ b/spec/services/duration_formatter_spec.rb
@@ -5,9 +5,8 @@ RSpec.describe DurationFormatter do
   subject(:service) { described_class.new(duration, style) }
 
   let(:duration) { 0 }
-  let(:style) { nil }
 
-  shared_examples 'expected thing' do
+  shared_examples 'expected string' do
     it 'returns expected string' do
       expect(service.call).to eq(expected_string)
     end
@@ -18,35 +17,35 @@ RSpec.describe DurationFormatter do
       let(:duration) { 92_098_000 }
       let(:expected_string) { '1:01:34:58' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
     end
 
     context 'with duration over an hour' do
       let(:duration) { 22_140_000 }
       let(:expected_string) { '6:09:00' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
     end
 
     context 'with duration over a minute' do
       let(:duration) { 2_254_000 }
       let(:expected_string) { '37:34' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
     end
 
     context 'with duration over a second' do
       let(:duration) { 34_000 }
       let(:expected_string) { '0:34' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
     end
 
     context 'with duration under a second' do
       let(:duration) { 700 }
       let(:expected_string) { '0:00' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
     end
   end
 
@@ -69,35 +68,49 @@ RSpec.describe DurationFormatter do
       let(:duration) { 92_098_000 }
       let(:expected_string) { '1d 1h 34m 58s' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
     end
 
     context 'with duration over an hour' do
       let(:duration) { 22_140_000 }
       let(:expected_string) { '6h 9m' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
+    end
+
+    context 'with duration exactly 2 hours' do
+      let(:duration) { 7_200_000 }
+      let(:expected_string) { '2h' }
+
+      include_examples 'expected string'
     end
 
     context 'with duration over a minute' do
       let(:duration) { 2_254_000 }
       let(:expected_string) { '37m 34s' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
+    end
+
+    context 'with duration exactly 2 minutes' do
+      let(:duration) { 120_000 }
+      let(:expected_string) { '2m' }
+
+      include_examples 'expected string'
     end
 
     context 'with duration over a second' do
       let(:duration) { 34_000 }
       let(:expected_string) { '0m 34s' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
     end
 
     context 'with duration under a second' do
       let(:duration) { 700 }
-      let(:expected_string) { '0m 0s' }
+      let(:expected_string) { '0s' }
 
-      include_examples 'expected thing'
+      include_examples 'expected string'
     end
   end
 end


### PR DESCRIPTION
Fixes #167

<img width="705" alt="Screen Shot 2019-08-03 at 7 26 16 PM" src="https://user-images.githubusercontent.com/104095/62418700-95370680-b624-11e9-8240-93c15934b5cf.png">
