### PR TITLE
Add next/previous performance links in track context menu

### DIFF
--- a/app/helpers/track_helper.rb
+++ b/app/helpers/track_helper.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+module TrackHelper
+  def next_gap_link(song, date) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    next_show =
+      Show.joins(tracks: :songs)
+          .published
+          .where('date > ?', date)
+          .where(songs: { id: song.id })
+          .order(date: :asc)
+          .first
+    return if next_show.blank?
+
+    track = next_show.tracks.find { |t| song.in?(t.songs) }
+    gap =
+      Show.published
+          .where('date BETWEEN ? AND ?', date, next_show.date)
+          .count
+    link_to(
+      "#{tag.i(class: 'icon-forward')} Next Performance (gap: #{gap})".html_safe,
+      "/#{next_show.date}/#{track.slug}"
+    )
+  end
+
+  def previous_gap_link(song, date) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    prev_show =
+      Show.joins(tracks: :songs)
+          .published
+          .where('date < ?', date)
+          .where(songs: { id: song.id })
+          .order(date: :desc)
+          .first
+    return if prev_show.blank?
+
+    track = prev_show.tracks.find { |t| song.in?(t.songs) }
+    gap =
+      Show.published
+          .where('date BETWEEN ? AND ?', prev_show.date, date)
+          .count
+    link_to(
+      "#{tag.i(class: 'icon-backward')} Previous Performance (gap: #{gap})".html_safe,
+      "/#{prev_show.date}/#{track.slug}"
+    )
+  end
+end

--- a/app/views/shared/_context_menu_for_track.html.slim
+++ b/app/views/shared/_context_menu_for_track.html.slim
@@ -38,3 +38,7 @@
             i.icon-book
             | &nbsp;
             = "#{song.title}..."
+        - if (show && link = next_gap_link(song, show.date))
+          li = link
+        - if (show && link = previous_gap_link(song, show.date))
+          li = link


### PR DESCRIPTION
Fixes #158 

<img width="757" alt="Screen Shot 2021-05-02 at 9 47 15 PM" src="https://user-images.githubusercontent.com/104095/116842075-2176b480-ab90-11eb-8c20-afbe940c7ac2.png">