### PR TITLE
Expose dark mode compatible waveform images

### DIFF
--- a/app/javascript/packs/application.css.scss
+++ b/app/javascript/packs/application.css.scss
@@ -508,8 +508,6 @@ html {
           position: absolute;
           width: 440px;
           height: 70px;
-          background-image: none; // TODO
-          background-color: transparent; // TODO
           cursor: pointer;
           margin-left: 30px;
           border: none;
@@ -525,10 +523,9 @@ html {
           border: none;
         }
         .ui-slider-range {
-          background-image: none; // TODO
           background: url('../images/progress-bar.png');
           border-radius: 0px;
-          // z-index: 100 !important; TODO
+          z-index: 100 !important;
         }
       }
       #time_elapsed {

--- a/app/javascript/src/coffeescript/player.js.coffee
+++ b/app/javascript/src/coffeescript/player.js.coffee
@@ -247,10 +247,9 @@ class Player
     @$scrubber.css('background-color', 'transparent')
     @$scrubber.css('opacity', 0)
     @$waveform.css('background-image', "url(#{r.waveform_image_url})")
-    # $('.ui-slider-range').css('mask-image', "url(#{r.waveform_image_url})") # TODO
+    $('.ui-slider-range').css('mask-image', "url(#{r.waveform_image_url})")
     setTimeout( =>
       @$scrubber.animate({ opacity: 1 }, { duration: 1000 });
-      @$scrubber.css('background-color', '#999999') # TODO
     , 500)
     @duration = Math.floor(r.duration / 1000)
     if r.title?.length > 26 then @$player_title.addClass 'long_title' else @$player_title.removeClass 'long_title'

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -57,7 +57,7 @@ class Track < ApplicationRecord
   end
 
   def waveform_image_url
-    waveform_image&.url(host: APP_BASE_URL)&.gsub('tracks/audio_files', 'audio')
+    waveform_png&.url(host: APP_BASE_URL)&.gsub('tracks/audio_files', 'audio')
   end
 
   def save_duration

--- a/config/initializers/app_constants.rb
+++ b/config/initializers/app_constants.rb
@@ -24,7 +24,10 @@ IMPORT_DIR = "#{APP_CONTENT_PATH}/import".freeze
 
 APP_BASE_URL =
   if Rails.env.in?(%w[development test])
-    'http://localhost:3000'
+    web_host = ENV.fetch('WEB_HOST', nil)
+    protocol = web_host ? 'https' : 'http'
+    host = web_host || 'localhost:3000'
+    "#{protocol}://#{host}"
   else
     'https://phish.in'
   end

--- a/lib/tasks/tracks.rake
+++ b/lib/tasks/tracks.rake
@@ -34,6 +34,23 @@ namespace :tracks do
     pbar.finish
   end
 
+  desc 'Delete legacy `waveform_image`s from Tracks'
+  task delete_legacy_waveforms: :environment do
+    relation = Track.where.not(waveform_image_data: nil)
+    pbar = ProgressBar.create(
+      total: relation.size,
+      format: '%a %B %c/%C %p%% %E'
+    )
+
+    relation.find_each do |track|
+      track.waveform_image = nil
+      track.save!
+      pbar.increment
+    end
+
+    pbar.finish
+  end
+
   desc 'Check for the same file being used for second occurrence of song within a show'
   task find_dupe_filenames: :environment do
     show_list = []

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Track do
   end
 
   it 'provides #waveform_image_url' do
-    url = track.waveform_image.url(host: APP_BASE_URL).gsub('tracks/audio_files', 'audio')
+    url = track.waveform_png.url(host: APP_BASE_URL).gsub('tracks/audio_files', 'audio')
     expect(track.waveform_image_url).to eq(url)
   end
 


### PR DESCRIPTION
Related to #269 

Exposes freshly generated dark mode compatible waveform images. With an extension like Dark Reader (shown below), seems to work well. This paves the way for a native dark mode that fixes some of the issues like highlight blue making current track unreadable.

<img width="1053" alt="Screenshot 2023-10-27 at 3 05 15 PM" src="https://github.com/jcraigk/phishin/assets/104095/6bb26d40-0bed-4da8-bb5b-f69c30c27dae">
