### PR TITLE
Improve Phish.net comparison tasks

### DIFF
--- a/app/javascript/packs/application.css.scss
+++ b/app/javascript/packs/application.css.scss
@@ -500,7 +500,7 @@ html {
           border: none;
         }
         .ui-slider-handle {
-          background-image: none !important; //Override jquery UI CSS
+          background-image: none !important; // Override jQuery UI CSS
           margin-top: 4px;
           margin-left: -4px !important;
           background-color: transparent;
@@ -508,6 +508,8 @@ html {
           height: 70px;
           cursor: pointer;
           border: none;
+          outline: none; // Prevent focus outline
+          pointer-events: none; // Prevent interaction if necessary
         }
         .ui-slider-range {
           background: url('../images/progress-bar.png');

--- a/app/javascript/src/coffeescript/app.js.coffee
+++ b/app/javascript/src/coffeescript/app.js.coffee
@@ -259,25 +259,17 @@ $ ->
     App.Player.nextTrack()
 
   # Scrubber (jQuery UI slider)
-  $('#scrubber').slider({
+  $('#scrubber').slider
     animate: false,
     range: 'min',
     max: 100,
     value: 0,
-    create: ->
-      # Fix knob in Safari and Firefox/Mac (offset vertically by 1 px)
-      if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') is -1)
-        $('#scrubber .ui-slider-handle').css('margin-top', '3px')
-      else if (navigator.userAgent.indexOf('Firefox') != -1 && navigator.userAgent.indexOf('Chrome') is -1)
-        $('#scrubber .ui-slider-handle').css('margin-top', '4px')
-      else
     start: ->
       App.Player.startScrubbing()
     stop: ->
       App.Player.stopScrubbing()
     slide: ->
       App.Player.moveScrubber()
-  }).slider('disable')
 
   # Volume slider (jQuery UI slider)
   $('#volume_slider').slider({

--- a/app/javascript/src/coffeescript/player.js.coffee
+++ b/app/javascript/src/coffeescript/player.js.coffee
@@ -26,8 +26,6 @@ class Player
 
   onReady: ->
     @time_marker = @Util.timeToMS($('body').data('time-marker'))
-    @$scrubber.slider()
-    @$scrubber.slider('enable')
 
     # Support next/prev buttons on mobile lock screens
     navigator.mediaSession.setActionHandler 'previoustrack', =>

--- a/app/models/show.rb
+++ b/app/models/show.rb
@@ -76,6 +76,10 @@ class Show < ApplicationRecord
     }
   end
 
+  def url
+    "#{APP_BASE_URL}/#{date}"
+  end
+
   private
 
   def show_tags_for_api

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -35,7 +35,7 @@ class Track < ApplicationRecord
   scope :tagged_with, ->(tag_slug) { joins(:tags).where(tags: { slug: tag_slug }) }
 
   def url
-    "#{APP_BASE_URL}/#{show.date.to_fs(:db)}/#{slug}"
+    "#{APP_BASE_URL}/#{show.date}/#{slug}"
   end
 
   def set_name

--- a/db/migrate/20240630030323_add_setlist_matches_phishnet_to_shows.rb
+++ b/db/migrate/20240630030323_add_setlist_matches_phishnet_to_shows.rb
@@ -1,0 +1,5 @@
+class AddSetlistMatchesPhishnetToShows < ActiveRecord::Migration[7.1]
+  def change
+    add_column :shows, :matches_pnet, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_27_223005) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_30_030323) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "announcements", force: :cascade do |t|
@@ -110,6 +111,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_27_223005) do
     t.integer "tags_count", default: 0
     t.boolean "published", default: false, null: false
     t.string "venue_name", default: "", null: false
+    t.boolean "matches_pnet", default: false
     t.index ["date"], name: "index_shows_on_date", unique: true
     t.index ["duration"], name: "index_shows_on_duration"
     t.index ["likes_count"], name: "index_shows_on_likes_count"

--- a/lib/tasks/phishnet.rake
+++ b/lib/tasks/phishnet.rake
@@ -5,7 +5,13 @@ namespace :phishnet do
     puts 'Fetching known dates from Phish.net API...'
     url = "https://api.phish.net/v5/shows.json?apikey=#{ENV['PNET_API_KEY']}"
     JSON.parse(Typhoeus.get(url).body)['data'].each do |entry|
-      next unless entry['artist_name'] == 'Phish' && entry['exclude_from_stats'] != '1'
+      next unless entry['artist_name'] == 'Phish' &&
+                  entry['exclude_from_stats'] != '1'
+
+      setlist_url = "https://api.phish.net/v5/setlists/showdate/#{entry['showdate']}.json?apikey=#{ENV['PNET_API_KEY']}"
+      setlist_count = JSON.parse(Typhoeus.get(url).body)['data'].size
+      next if setlist_count.zero?
+
       kdate = KnownDate.find_or_create_by(date: entry['showdate'])
       location = entry['city']
       location += ", #{entry['state']}" if entry['state'].present?

--- a/lib/tasks/shows.rake
+++ b/lib/tasks/shows.rake
@@ -28,45 +28,4 @@ namespace :shows do
     puts "🔎 #{pluralize(dates.size, 'folder')} found"
     dates.each { |date| ShowImporter::Cli.new(date) }
   end
-
-  desc 'Compare setlists with Phish.net'
-  task match_pnet: :environment do
-    # "A > B" => ["A", "B"]
-    def expand(setlist)
-      normalized = []
-      setlist.each do |set, title|
-        if title.include?(' > ')
-          titles = title.split(' > ')
-          titles.each { |t| normalized << [set, t] }
-        else
-          normalized << [set, title]
-        end
-      end
-      normalized
-    end
-
-    shows = Show.published.where(incomplete: false).order(date: :asc)
-    pbar = ProgressBar.create \
-      total: shows.count,
-      format: '%a %B %c/%C %p%% %E'
-
-    shows.each do |show|
-      url = "https://api.phish.net/v5/setlists/showdate/#{show.date}.json?apikey=#{ENV['PNET_API_KEY']}"
-      sa = JSON.parse(Typhoeus.get(url).body)['data'].map { |d| [d['set'].upcase, d['song']] }
-      sb = expand \
-        show.tracks
-            .where.not(title: 'Banter')
-            .where(matches_pnet: false)
-            .order(:position)
-            .map { |t| [t.set, t.title] }
-      if sa == sb
-        show.update(matches_pnet: true)
-      else
-
-      end
-      pbar.increment
-    end
-
-    pbar.finish
-  end
 end

--- a/lib/tasks/shows.rake
+++ b/lib/tasks/shows.rake
@@ -28,4 +28,45 @@ namespace :shows do
     puts "🔎 #{pluralize(dates.size, 'folder')} found"
     dates.each { |date| ShowImporter::Cli.new(date) }
   end
+
+  desc 'Compare setlists with Phish.net'
+  task match_pnet: :environment do
+    # "A > B" => ["A", "B"]
+    def expand(setlist)
+      normalized = []
+      setlist.each do |set, title|
+        if title.include?(' > ')
+          titles = title.split(' > ')
+          titles.each { |t| normalized << [set, t] }
+        else
+          normalized << [set, title]
+        end
+      end
+      normalized
+    end
+
+    shows = Show.published.where(incomplete: false).order(date: :asc)
+    pbar = ProgressBar.create \
+      total: shows.count,
+      format: '%a %B %c/%C %p%% %E'
+
+    shows.each do |show|
+      url = "https://api.phish.net/v5/setlists/showdate/#{show.date}.json?apikey=#{ENV['PNET_API_KEY']}"
+      sa = JSON.parse(Typhoeus.get(url).body)['data'].map { |d| [d['set'].upcase, d['song']] }
+      sb = expand \
+        show.tracks
+            .where.not(title: 'Banter')
+            .where(matches_pnet: false)
+            .order(:position)
+            .map { |t| [t.set, t.title] }
+      if sa == sb
+        show.update(matches_pnet: true)
+      else
+
+      end
+      pbar.increment
+    end
+
+    pbar.finish
+  end
 end


### PR DESCRIPTION
* Add `phishnet:compare_setlists` task for investigating setlist disparities between in/net
* Update `phishnet:known_dates` to exclude shows for which setlists are unknown
* Bonus: Fixes #370