### PR TITLE
Add .env.example documenting available settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,62 @@
+# Copy this file to `.env` and fill in the values you need.
+# The app boots for local development without any of these set; each
+# section notes what stops working when a value is missing.
+
+# --- Content import -------------------------------------------------
+# Phish.net API key, required by `rails shows:import` and the jamcharts
+# and gap jobs. Request one at https://docs.phish.net/
+PNET_API_KEY=
+
+# Serve audio, waveforms, and album art from phish.in instead of local
+# content. Handy when working from the development SQL dump without
+# having any MP3s on disk. Set to false when verifying a local import.
+PRODUCTION_CONTENT=true
+
+# Where `rails shows:import` looks for dated MP3 folders.
+# Defaults to /content/import.
+# IMPORT_PATH=
+
+# --- Maps -----------------------------------------------------------
+# Mapbox public token. Venue maps and map search render nothing without
+# it; the rest of the site is unaffected.
+MAPBOX_TOKEN=
+
+# Optional separate token for venue map snapshot jobs. Falls back to
+# MAPBOX_TOKEN when unset.
+# MAPBOX_STATIC_TOKEN=
+
+# --- Google OAuth ---------------------------------------------------
+# Needed to sign in locally.
+OAUTH_GOOGLE_KEY=
+OAUTH_GOOGLE_SECRET=
+
+# --- Sidekiq web UI -------------------------------------------------
+# Both are required to open /sidekiq.
+SIDEKIQ_USERNAME=
+SIDEKIQ_PASSWORD=
+
+# --- Mail -----------------------------------------------------------
+SMTP_ADDRESS=
+SMTP_USERNAME=
+SMTP_PASSWORD=
+
+# --- AI features ----------------------------------------------------
+# Cover art generation.
+OPENAI_API_TOKEN=
+# Lore sync.
+ANTHROPIC_API_KEY=
+
+# --- Deployment -----------------------------------------------------
+# Public hostname. When unset, URLs are built from http://localhost:3000.
+# WEB_HOST=
+# MEMCACHED_URL=
+# REDIS_URL=
+# SENTRY_DSN=
+# RAILS_MAX_THREADS=5
+# ALBUM_DISK_LIMIT_GB=250
+
+# Backups.
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_REGION=
+# AWS_BUCKET=

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Join the [Discord](https://discord.gg/KZWFsNN) to discuss content and developmen
 1. Install [Docker](https://www.docker.com/)
 
 2. Clone the repo to your local machine
-3. Create a `.env` file at the root of the repository
+3. Create a `.env` file at the root of the repository (copy `.env.example` for the available settings)
 4. Run `mise run services`
 
 5. Download the [Development SQL File](https://www.dropbox.com/scl/fi/6zv4bzxxcjgv3ouv8d3ek/phishin-dev.sql?rlkey=4trafp2vxcgc1iuuq36yhl9gc) and import it:


### PR DESCRIPTION
Setup step 3 says to create a `.env` file but doesn't say what can go in it, so I ended up grepping for `ENV.fetch` to work out what the app actually reads. This adds a `.env.example` so it's discoverable up front, plus a pointer to it from that README step.

Each section notes what stops working when a value is missing, which was the part I actually wanted to know as a first-time contributor: the app boots fine without any of it, but venue maps and map search render nothing without `MAPBOX_TOKEN`, `/sidekiq` won't load unless both credentials are set, and `rails shows:import` needs `PNET_API_KEY`.

Everything is blank except `PRODUCTION_CONTENT=true`, since working from the development SQL dump without local MP3s seemed like the common starting point.

Deliberately left out `IN_DOCKER`, since the Dockerfile already sets it and putting it here would just invite people to set it wrong, along with the rake task arguments (`DATE`, `LIMIT`, `DRY_RUN`, and friends) since those aren't configuration.

Happy to trim the deployment section if you'd rather keep this focused on local dev only.